### PR TITLE
docs: link repo in exploit guide

### DIFF
--- a/ExploitGuide.html
+++ b/ExploitGuide.html
@@ -2,6 +2,8 @@
 
 <blockquote class='border-l-4 pl-4 italic text-slate-600'>**Educational use only.** These steps are designed for the RatTasks lab running on your own machine. Do not target systems you don’t own or don’t have explicit permission to test.</blockquote>
 
+<p>Project repository: <a href="https://github.com/The-XSS-Rat/RatDo">https://github.com/The-XSS-Rat/RatDo</a></p>
+
 <p>---</p>
 
 <h2 class='text-2xl font-bold mt-6 mb-3'>0) Setup</h2>

--- a/ExploitGuide.md
+++ b/ExploitGuide.md
@@ -2,6 +2,8 @@
 
 > **Educational use only.** These steps are designed for the RatTasks lab running on your own machine. Do not target systems you don’t own or don’t have explicit permission to test.
 
+Project repository: [https://github.com/The-XSS-Rat/RatDo](https://github.com/The-XSS-Rat/RatDo)
+
 ---
 
 ## 0) Setup


### PR DESCRIPTION
## Summary
- link project repository in the markdown and HTML exploit guides

## Testing
- `python -m py_compile RatDo.py`


------
https://chatgpt.com/codex/tasks/task_b_68bd79fcb6048329b079f2ddc5f3afc9